### PR TITLE
Castle Grounds: Change far plane culling to be more accurate

### DIFF
--- a/levels/castle_grounds/areas/1/geo.inc.c
+++ b/levels/castle_grounds/areas/1/geo.inc.c
@@ -11,7 +11,7 @@ const GeoLayout castle_grounds_geo_00073C[] = {
       GEO_CLOSE_NODE(),
       GEO_ZBUFFER(1),
       GEO_OPEN_NODE(),
-         GEO_CAMERA_FRUSTUM_WITH_FUNC(45, 100, 20000, geo_camera_fov),
+         GEO_CAMERA_FRUSTUM_WITH_FUNC(45, 100, 12800, geo_camera_fov),
          GEO_OPEN_NODE(),
             GEO_CAMERA(16, 0, 1500, 2500, 0, 1500, -12000, geo_camera_main),
             GEO_OPEN_NODE(),


### PR DESCRIPTION
I remember Fluvian said "Oh yeah, I just noticed this while adjusting the cutscene" or something like that. It doesn't seem to be in the release.