### PR TITLE
CastleGrounds: Make the far plane culling accurate

### DIFF
--- a/levels/castle_grounds/areas/1/custom/geo.inc.c
+++ b/levels/castle_grounds/areas/1/custom/geo.inc.c
@@ -11,7 +11,7 @@ const GeoLayout castle_grounds_geo[] = {
       GEO_CLOSE_NODE(),
       GEO_ZBUFFER(1),
       GEO_OPEN_NODE(),
-         GEO_CAMERA_FRUSTUM_WITH_FUNC(45, 100, 20000, geo_camera_fov),
+         GEO_CAMERA_FRUSTUM_WITH_FUNC(45, 100, 12800, geo_camera_fov),
          GEO_OPEN_NODE(),
             GEO_CAMERA(16, 0, 1500, 2500, 0, 1500, -12000, geo_camera_main),
             GEO_OPEN_NODE(),


### PR DESCRIPTION
I've seen the value of `12800` used for other gigaleak stages, and I've done some comparing and came to the conclusion that this most likely is the right value.


I have created a NEW pull request because I realized the old one (#11) modified the wrong file.  Don't mind it.