### PR TITLE
Behaviors/Boo: Fix Boo dies when Mario gets hit

### DIFF
--- a/src/game/behaviors/boo.inc.c
+++ b/src/game/behaviors/boo.inc.c
@@ -294,8 +294,7 @@ static s32 boo_get_attack_status(void) {
     s32 attackStatus = BOO_NOT_ATTACKED;
 
     if (o->oInteractStatus & INT_STATUS_INTERACTED) {
-        if ((o->oInteractStatus & INT_STATUS_WAS_ATTACKED)
-            && obj_has_attack_type(ATTACK_FROM_ABOVE) == FALSE) {
+        if (o->oInteractStatus & INT_STATUS_WAS_ATTACKED) {
             cur_obj_become_intangible();
 
             o->oInteractStatus = 0;
@@ -404,7 +403,7 @@ static void boo_act_1(void) {
     }
 
     if (attackStatus == BOO_BOUNCED_ON) {
-        o->oAction = 3;
+        o->oAction = 2;
     }
 
     if (attackStatus == BOO_ATTACKED) {


### PR DESCRIPTION
When Mario collides with a Boo, he gets hurt, and the Boo itself dies as well. This fixes it.

Original behavior:
![image](https://user-images.githubusercontent.com/17717494/172769188-0687a4fc-587f-45c5-a796-348a67b454e3.png)

Current (and expected) behavior:
![image](https://user-images.githubusercontent.com/17717494/172769255-63480061-3397-4400-af02-c8cd9a970989.png)

