### PR TITLE
Update Dockerfile to Ubuntu 22.04 as 18.04 is EOL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,17 @@
-FROM ubuntu:18.04 as build
+FROM ubuntu:22.04 as build
 
 RUN apt-get update && \
     apt-get install -y \
         binutils-mips-linux-gnu \
-        bsdmainutils \
+        bsdextrautils \
         build-essential \
         libaudiofile-dev \
         libcapstone-dev \
-        python3 \
-        wget
+        python3
 
-RUN wget \
-        https://github.com/n64decomp/qemu-irix/releases/download/v2.11-deb/qemu-irix-2.11.0-2169-g32ab296eef_amd64.deb \
-        -O qemu.deb && \
-    echo 8170f37cf03a08cc2d7c1c58f10d650ea0d158f711f6916da9364f6d8c85f741 qemu.deb | sha256sum --check && \
-    dpkg -i qemu.deb && \
-    rm qemu.deb
+RUN mkdir /tpp
+WORKDIR /tpp
+ENV PATH="/tpp/tools:${PATH}"
 
-RUN mkdir /sm64
-WORKDIR /sm64
-ENV PATH="/sm64/tools:${PATH}"
-
-CMD echo 'usage: docker run --rm --mount type=bind,source="$(pwd)",destination=/sm64 sm64 make VERSION=${VERSION:-us} -j4\n' \
-         'see https://github.com/n64decomp/sm64/blob/master/README.md for advanced usage'
+CMD echo 'Usage: docker run --rm -v${PWD}:/tpp tpp make VERSION= jp -j4\n' \
+         'See https://github.com/Fluvian/tpp/blob/master/README.md for more information'

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ For each version (jp/us/eu) that you want to build a ROM for, put an existing RO
 #### 2. Create docker image
 
 ```bash
-docker build -t sm64 .
+docker build -t tpp .
 ```
 
 #### 3. Build
@@ -91,10 +91,10 @@ To build we simply have to mount our local filesystem into the docker container 
 
 ```bash
 # for example if you have baserom.us.z64 in the project root
-docker run --rm --mount type=bind,source="$(pwd)",destination=/sm64 sm64 make VERSION=us -j4
+docker run --rm -v ${PWD}:/tpp tpp make VERSION=jp -j4
 
 # if your host system is linux you need to tell docker what user should own the output files
-docker run --rm --mount type=bind,source="$(pwd)",destination=/sm64 --user $UID:$UID sm64 make VERSION=us -j4
+docker run --rm -v ${PWD}:/tpp --user $UID:$UID tpp make VERSION=jp -j4
 ```
 
 Resulting artifacts can be found in the `build` directory.


### PR DESCRIPTION
Relevant pull at the original decomp repo: https://github.com/n64decomp/sm64/pull/91